### PR TITLE
implemented new evaluate() and evaluateAndJacobians() 

### DIFF
--- a/curves/include/curves/Evaluator.hpp
+++ b/curves/include/curves/Evaluator.hpp
@@ -31,10 +31,12 @@ class Evaluator : public EvaluatorBase
   virtual ValueType evaluate(const std::vector<Coefficient>& coefficients) const = 0;
 
   /// Evaluate the ambient space of the curve (functional form) with original coefficients.
-  virtual ValueType evaluateAndJacobians(std::vector<Eigen::MatrixXd>* outJacobian) const = 0;
-  
-  /// Evaluate the ambient space of the curve (functional form) by specifying new coefficients.
-  virtual ValueType evaluateAndJacobians(const std::vector<Coefficient>& coefficients, std::vector<Eigen::MatrixXd>* outJacobians) const = 0;
+  virtual ValueType evaluateAndJacobians(const Eigen::MatrixXd& chainRule,
+                                         const std::vector<Eigen::MatrixXd*>& jacobians) const = 0;
+
+  virtual ValueType evaluateAndJacobians(const std::vector<Coefficient>& coefficients,
+                                         const Eigen::MatrixXd& chainRule,
+                                         const std::vector<Eigen::MatrixXd*>& jacobians) const = 0;
 
   /// Evaluate the curve derivatives (functional form).
   virtual Eigen::VectorXd evaluateDerivative(unsigned derivativeOrder, const std::vector<Coefficient>& coefficients) const = 0;
@@ -45,11 +47,6 @@ class Evaluator : public EvaluatorBase
   /// Get the maximum derivative order supported by this evaluator.
   size_t getMaximumDerivativeOrder() const;
 
-  virtual ValueType evaluate(const boost::unordered_map<Key, Coefficient>& keyCoefficient) const = 0;
-
-  virtual ValueType evaluateAndJacobians(const boost::unordered_map<Key, Coefficient>& keyCoefficient,
-                                         const boost::unordered_map<Key, Eigen::MatrixXd*>& keyJacobian,
-                                         const Eigen::MatrixXd& chainRule) const = 0;
 };
 
 } // namespace 

--- a/curves/include/curves/LinearInterpolationVectorSpaceEvaluator.hpp
+++ b/curves/include/curves/LinearInterpolationVectorSpaceEvaluator.hpp
@@ -33,11 +33,12 @@ class LinearInterpolationVectorSpaceEvaluator : public Evaluator<VectorSpaceConf
   virtual ValueType evaluate(const std::vector<Coefficient>& coefficients) const;
 
   /// Evaluate the ambient space of the curve (functional form) with original coefficients.
-  virtual ValueType evaluateAndJacobians(std::vector<Eigen::MatrixXd>* outJacobians) const;
+  virtual ValueType evaluateAndJacobians(const Eigen::MatrixXd& chainRule,
+                                         const std::vector<Eigen::MatrixXd*>& jacobians) const;
 
-  /// Evaluate the ambient space of the curve (functional form) by specifying new coefficients.
   virtual ValueType evaluateAndJacobians(const std::vector<Coefficient>& coefficients,
-                                         std::vector<Eigen::MatrixXd>* outJacobians) const;
+                                         const Eigen::MatrixXd& chainRule,
+                                         const std::vector<Eigen::MatrixXd*>& jacobians) const;
 
   /// Evaluate the curve derivatives.
   virtual Eigen::VectorXd evaluateDerivative(unsigned derivativeOrder) const;
@@ -55,13 +56,6 @@ class LinearInterpolationVectorSpaceEvaluator : public Evaluator<VectorSpaceConf
                                                         const std::vector<Coefficient>& coefficients,
                                                         std::vector<Eigen::MatrixXd>* outJacobian) const;
 
-  virtual ValueType evaluate(const boost::unordered_map<Key, Coefficient>& keyCoefficient) const;
-
-  virtual ValueType evaluateAndJacobians(const boost::unordered_map<Key, Coefficient>& keyCoefficient,
-                                         const boost::unordered_map<Key, Eigen::MatrixXd*>& keyJacobian,
-                                         const Eigen::MatrixXd& chainRule) const;
-
-
  private:
 
   const LinearInterpolationVectorSpaceCurve& curve_;
@@ -70,7 +64,6 @@ class LinearInterpolationVectorSpaceEvaluator : public Evaluator<VectorSpaceConf
   double alpha_;
   double oneMinusAlpha_;
   size_t dimension_;
-  std::vector<Eigen::MatrixXd> jacobians_;
 
 };
 


### PR DESCRIPTION
Implemented new functions for making real adaptive factors (no switch case). The rest of the solution will be in AdaptiveOdometryFactor::unwhitenedError() on the trajectory_maintainer gitrepo : 

https://github.com/ethz-asl/continuous-trajectory-scanmatching

The old evaluate() and evaluateAndJacobians() were kept until the adaptive factor architecture is validated.

Thanks for commenting. 
