### PR TITLE
fix for being able to evaluate the curve when there is only one coefficient

### DIFF
--- a/curves/src/SlerpSE3Curve.cpp
+++ b/curves/src/SlerpSE3Curve.cpp
@@ -152,20 +152,25 @@ SlerpSE3Curve::getDerivativeExpression(const Time& time, unsigned derivativeOrde
 }
 
 SE3 SlerpSE3Curve::evaluate(Time time) const {
-  CoefficientIter a, b;
-  bool success = manager_.getCoefficientsAt(time, &a, &b);
-  CHECK(success) << "Unable to get the coefficients at time " << time;
-  SE3 T_W_A = a->second.coefficient;
-  SE3 T_W_B = b->second.coefficient;
-  double alpha = double(time - a->first)/double(b->first - a->first);
+  // Check if the curve is only defined at this one time
+  if (manager_.getMaxTime() == time && manager_.getMinTime() == time) {
+    return manager_.coefficientBegin()->second.coefficient;
+  } else {
+    CoefficientIter a, b;
+    bool success = manager_.getCoefficientsAt(time, &a, &b);
+    CHECK(success) << "Unable to get the coefficients at time " << time;
+    SE3 T_W_A = a->second.coefficient;
+    SE3 T_W_B = b->second.coefficient;
+    double alpha = double(time - a->first)/double(b->first - a->first);
 
-  //Implementation of T_W_I = T_W_A*exp(alpha*log(inv(T_W_A)*T_W_B))
-  using namespace kindr::minimal;
-  SE3 T_A_B = invertAndComposeImplementation(T_W_A, T_W_B, boost::none, boost::none);
-  gtsam::Vector6 log_T_A_B = transformationLogImplementation(T_A_B, boost::none);
-  gtsam::Vector6 log_T_A_I = vectorScalingImplementation<int(6)>(log_T_A_B, alpha, boost::none, boost::none);
-  SE3 T_A_I = transformationExpImplementation(log_T_A_I, boost::none);
-  return composeImplementation(T_W_A, T_A_I, boost::none, boost::none);
+    //Implementation of T_W_I = T_W_A*exp(alpha*log(inv(T_W_A)*T_W_B))
+    using namespace kindr::minimal;
+    SE3 T_A_B = invertAndComposeImplementation(T_W_A, T_W_B, boost::none, boost::none);
+    gtsam::Vector6 log_T_A_B = transformationLogImplementation(T_A_B, boost::none);
+    gtsam::Vector6 log_T_A_I = vectorScalingImplementation<int(6)>(log_T_A_B, alpha, boost::none, boost::none);
+    SE3 T_A_I = transformationExpImplementation(log_T_A_I, boost::none);
+    return composeImplementation(T_W_A, T_A_I, boost::none, boost::none);
+  }
 }
 
 void SlerpSE3Curve::setTimeRange(Time minTime, Time maxTime) {


### PR DESCRIPTION
When developping the Trajectory_Optimizer we ran into an issue when trying to evaluate a curve which contains only one coefficient. A CHECK in `getCoefficientsAt()` failed, stopping the program. This is a proposition for solving this issue.
