### PR TITLE
fixed wrong dependencies in cmake scripts

### DIFF
--- a/curves/CMakeLists.txt
+++ b/curves/CMakeLists.txt
@@ -26,12 +26,12 @@ add_subdirectory(doc/doxygen)
 catkin_package(
   INCLUDE_DIRS
     include
+    ${EIGEN3_INCLUDE_DIR}
   LIBRARIES
     ${PROJECT_NAME}
   CATKIN_DEPENDS
   DEPENDS
-    eigen
-    boost
+    Boost
     glog
     kindr
 )

--- a/curves/package.xml
+++ b/curves/package.xml
@@ -16,7 +16,7 @@
   <author>Gabriel Agamennoni</author>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>kindr</depend>
-  <depend>eigen</depend>
+  <build_export_depend>eigen</build_export_depend>
   <depend>boost</depend>
   <depend>libgoogle-glog-dev</depend>
 </package>

--- a/curves_ros/CMakeLists.txt
+++ b/curves_ros/CMakeLists.txt
@@ -42,8 +42,6 @@ catkin_package(
     curves
     kindr_ros
     trajectory_msgs
-  DEPENDS
-    eigen
 )
 
 include_directories(
@@ -59,12 +57,6 @@ add_library(
   src/RosMultiDOFJointTrajectoryInterface.cpp
   src/RosMultiDOFJointTrajectoryTranslationInterface.cpp
 )
-
-add_dependencies(
-  ${PROJECT_NAME}
-  curves
-  roscpp
-  trajectory_msgs)
 
 target_link_libraries(
   ${PROJECT_NAME}

--- a/curves_ros/package.xml
+++ b/curves_ros/package.xml
@@ -12,5 +12,5 @@
   <depend>curves</depend>
   <depend>kindr_ros</depend>
   <depend>trajectory_msgs</depend>
-  <depend>eigen</depend>
+  <build_export_depend>eigen</build_export_depend>
 </package>


### PR DESCRIPTION
This should get rid of the warnings when compiling for xenail / kinetic.
Also required for cross compiling.